### PR TITLE
Restrict service worker caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -10,6 +10,30 @@ const APP_SHELL = [
   '/Carta-Nomo/favicon.ico'
 ];
 
+const ORIGIN_WHITELIST = ['https://firebasestorage.googleapis.com'];
+const MAX_CACHE_ITEMS = 60;
+const MAX_CACHE_AGE = 30 * 24 * 60 * 60 * 1000; // 30 días
+
+async function enforceCacheLimits(cache) {
+  const keys = await cache.keys();
+  const now = Date.now();
+
+  await Promise.all(
+    keys.map(async (req) => {
+      const res = await cache.match(req);
+      const date = res?.headers.get('date');
+      if (date && now - new Date(date).getTime() > MAX_CACHE_AGE) {
+        await cache.delete(req);
+      }
+    })
+  );
+
+  const remaining = await cache.keys();
+  while (remaining.length > MAX_CACHE_ITEMS) {
+    await cache.delete(remaining.shift());
+  }
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
   self.skipWaiting();
@@ -26,38 +50,50 @@ self.addEventListener('activate', (event) => {
 
 // Network-first para HTML, SWR para estáticos e imágenes (incluye Firebase Storage)
 self.addEventListener('fetch', (event) => {
-  const { request } = event; const url = new URL(request.url);
+  const { request } = event;
+  const url = new URL(request.url);
   if (request.method !== 'GET') return;
+
+  const allowed = url.origin === location.origin || ORIGIN_WHITELIST.includes(url.origin);
+  if (!allowed) return;
 
   if (request.headers.get('accept')?.includes('text/html')) {
     event.respondWith(
-      fetch(request).then((res) => {
-        const copy = res.clone(); if (copy.ok && copy.status === 200) caches.open(CACHE_NAME).then((c) => c.put(request, copy));
-        return res;
-      }).catch(() => caches.match(request).then((r) => r || caches.match('/Carta-Nomo/index.html')))
-    );
-    return;
-  }
-
-  if (url.origin === location.origin) {
-    event.respondWith(
-      caches.match(request).then((cached) => {
-        const fetchPromise = fetch(request).then((networkRes) => {
-          if (networkRes && networkRes.status === 200) caches.open(CACHE_NAME).then((cache) => cache.put(request, networkRes.clone()));
-          return networkRes;
-        }).catch(() => cached);
-        return cached || fetchPromise;
-      })
+      fetch(request)
+        .then(async (res) => {
+          const copy = res.clone();
+          if (
+            copy.ok &&
+            copy.status === 200 &&
+            !/no-store|no-cache/i.test(copy.headers.get('Cache-Control') || '')
+          ) {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.put(request, copy);
+            enforceCacheLimits(cache);
+          }
+          return res;
+        })
+        .catch(() => caches.match(request).then((r) => r || caches.match('/Carta-Nomo/index.html')))
     );
     return;
   }
 
   event.respondWith(
     caches.match(request).then((cached) => {
-      const fetchPromise = fetch(request).then((networkRes) => {
-        if (networkRes && networkRes.status === 200) caches.open(CACHE_NAME).then((cache) => cache.put(request, networkRes.clone()));
-        return networkRes;
-      }).catch(() => cached);
+      const fetchPromise = fetch(request)
+        .then(async (networkRes) => {
+          if (
+            networkRes &&
+            networkRes.status === 200 &&
+            !/no-store|no-cache/i.test(networkRes.headers.get('Cache-Control') || '')
+          ) {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.put(request, networkRes.clone());
+            enforceCacheLimits(cache);
+          }
+          return networkRes;
+        })
+        .catch(() => cached);
       return cached || fetchPromise;
     })
   );


### PR DESCRIPTION
## Summary
- limit caching to same-origin or whitelisted origins
- avoid caching responses with no-store or no-cache headers
- add cache limits by item count and age

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fb106049c83239aea0e801ec02060