### PR TITLE
Load Firebase config from external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -14,6 +14,32 @@ Una app web interactiva para visualizar, editar y escuchar palabras asociadas a 
   - Storage: subida de imágenes.
 - 📱 **PWA lista para móvil**: se puede instalar como app en dispositivos.
 
+## 🔐 Configuración segura
+
+Las credenciales de Firebase ya no se incluyen en el código fuente. La aplicación
+carga un archivo `config.json` al iniciar, por lo que debes proporcionar este
+archivo en el entorno de despliegue y mantenerlo fuera del control de versiones.
+
+1. Crea un archivo `config.json` junto a `index.html` con el siguiente formato:
+
+```json
+{
+  "apiKey": "...",
+  "authDomain": "...",
+  "projectId": "...",
+  "storageBucket": "...",
+  "messagingSenderId": "...",
+  "appId": "...",
+  "measurementId": "..."
+}
+```
+
+2. Usa variables de entorno u otros mecanismos seguros para generar ese archivo
+   sin exponer las claves en el repositorio.
+
+La aplicación realiza un `fetch` a `/config.json` para inicializar Firebase, por
+lo que el archivo debe estar accesible en el servidor.
+
 ## 📄 Licencia
 
 Este proyecto está bajo la licencia [MIT](LICENSE).

--- a/app.js
+++ b/app.js
@@ -3,15 +3,10 @@
     import { getFirestore, collection, doc, setDoc, deleteDoc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
     import { getStorage, ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyAqqDLPFmtAPHXm5ZzpHyxRZZpW31f4Of0",
-      authDomain: "carta-nomo.firebaseapp.com",
-      projectId: "carta-nomo",
-      storageBucket: "carta-nomo.firebasestorage.app",
-      messagingSenderId: "354109744323",
-      appId: "1:354109744323:web:d7548e8cfd0a1d4a41ae76",
-      measurementId: "G-LWB4H4F6TD"
-    };
+    // Carga de configuración segura
+    const configResp = await fetch('/config.json');
+    if (!configResp.ok) throw new Error('No se pudo cargar /config.json');
+    const firebaseConfig = await configResp.json();
 
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- load Firebase config by fetching `/config.json`
- document secure setup and add example config
- ignore local config.json and package-lock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb32e34e483239ba2e77b52a48c62