### PR TITLE
refactor: use firebase modules via npm

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword, signOut, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
-    import { getFirestore, collection, doc, setDoc, deleteDoc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
-    import { getStorage, ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
+    import { initializeApp } from "firebase/app";
+    import { getAuth, signInWithEmailAndPassword, signOut, onAuthStateChanged } from "firebase/auth";
+    import { getFirestore, collection, doc, setDoc, deleteDoc, onSnapshot } from "firebase/firestore";
+    import { getStorage, ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "firebase/storage";
 
     // Carga de configuración segura
     const configResp = await fetch('/config.json');

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "firebase": "^11.0.1"
+  }
 }


### PR DESCRIPTION
## Summary
- use Firebase modules via npm instead of CDN
- declare Firebase dependency in package.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb589d46883239cc9eb624dcd114d