### PR TITLE
Use relative asset paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -237,7 +237,7 @@
 
     // Service Worker
     if ('serviceWorker' in navigator){
-      window.addEventListener('load', () => navigator.serviceWorker.register('/Carta-Nomo/service-worker.js'));
+      window.addEventListener('load', () => navigator.serviceWorker.register('./service-worker.js'));
     }
 
     })();

--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://firebasestorage.googleapis.com; connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com; object-src 'none'; base-uri 'self';" />
   <title>Carta Nomo · Sarria — Liquid Glass</title>
 
-  <!-- PWA en GitHub Pages (/Carta-Nomo/) -->
-  <link rel="manifest" href="/Carta-Nomo/manifest.json" />
+  <!-- PWA local -->
+  <link rel="manifest" href="./manifest.json" />
   <meta name="theme-color" content="#ffffff" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  <link rel="apple-touch-icon" href="/Carta-Nomo/icons/icon-192.png" />
-  <link rel="icon" href="/Carta-Nomo/favicon.ico" />
+  <link rel="apple-touch-icon" href="./icons/icon-192.png" />
+  <link rel="icon" href="./favicon.ico" />
 
-  <link rel="stylesheet" href="/Carta-Nomo/styles.css">
+  <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
   <div class="page">
@@ -80,7 +80,7 @@
   </div>
 
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
-    <script type="module" src="/Carta-Nomo/app.js"></script>
+    <script type="module" src="./app.js"></script>
 
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,14 @@
   "short_name": "Carta Nomo",
   "description": "Explora la carta tocando números: muestra palabra e imagen, con lectura en voz alta.",
   "lang": "es-ES",
-  "start_url": "/Carta-Nomo/",
-  "scope": "/Carta-Nomo/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
-    { "src": "/Carta-Nomo/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/Carta-Nomo/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+    { "src": "./icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "./icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,15 +1,15 @@
-/* Service Worker para Carta Nomo (scope: /Carta-Nomo/) */
+/* Service Worker para Carta Nomo (scope: ./) */
 const VERSION = 'v1.0.1';
 const CACHE_NAME = `carta-nomo-${VERSION}`;
 const APP_SHELL = [
-  '/Carta-Nomo/',
-  '/Carta-Nomo/index.html',
-  '/Carta-Nomo/app.js',
-  '/Carta-Nomo/styles.css',
-  '/Carta-Nomo/manifest.json',
-  '/Carta-Nomo/icons/icon-192.png',
-  '/Carta-Nomo/icons/icon-512.png',
-  '/Carta-Nomo/favicon.ico'
+  './',
+  './index.html',
+  './app.js',
+  './styles.css',
+  './manifest.json',
+  './icons/icon-192.png',
+  './icons/icon-512.png',
+  './favicon.ico'
 ];
 
 const ORIGIN_WHITELIST = ['https://firebasestorage.googleapis.com'];
@@ -75,7 +75,7 @@ self.addEventListener('fetch', (event) => {
           }
           return res;
         })
-        .catch(() => caches.match(request).then((r) => r || caches.match('/Carta-Nomo/index.html')))
+        .catch(() => caches.match(request).then((r) => r || caches.match('./index.html')))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- replace absolute URLs in index.html with relative paths
- register the service worker using a relative path
- make PWA assets relative in manifest and service worker for portability

## Testing
- `npm test`
- `node -e "const fs=require('fs');['./styles.css','./app.js','./manifest.json','./icons/icon-192.png','./service-worker.js'].forEach(p=>console.log(p,fs.existsSync(p)));"`


------
https://chatgpt.com/codex/tasks/task_e_688fc2eecfdc83239a1ef746d4c3951a