### PR TITLE
Refresh grid after saving number

### DIFF
--- a/app.js
+++ b/app.js
@@ -187,6 +187,9 @@
         imagenUrl = await getDownloadURL(ref);
       }
       await setDoc(doc(collection(db, 'numeros'), String(n)), { palabra: palabra || '', imagenUrl: imagenUrl || null, updatedAt: Date.now() });
+      datos[n] = { palabra: palabra || '', imagenUrl: imagenUrl || null };
+      actualizarCelda(grid.children[n-1], n);
+      try { localStorage.setItem('datos', JSON.stringify(datos)); } catch {}
       return true;
     }
 


### PR DESCRIPTION
## Summary
- Update local cache and grid cell immediately after saving a number
- Persist updated data to localStorage for offline cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689061a1d31c8323a3b7070f33adeca4