### PR TITLE
fix: update icon paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta name="theme-color" content="#ffffff" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  <link rel="apple-touch-icon" href="/Carta-Nomo/iconos/icon-192.png" />
+  <link rel="apple-touch-icon" href="/Carta-Nomo/icons/icon-192.png" />
   <link rel="icon" href="/Carta-Nomo/favicon.ico" />
 
   <link rel="stylesheet" href="styles.css" />

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
-    { "src": "/Carta-Nomo/iconos/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/Carta-Nomo/iconos/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+    { "src": "/Carta-Nomo/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "/Carta-Nomo/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,8 +6,8 @@ const APP_SHELL = [
   '/Carta-Nomo/index.html',
   '/Carta-Nomo/styles.css',
   '/Carta-Nomo/manifest.json',
-  '/Carta-Nomo/iconos/icon-192.png',
-  '/Carta-Nomo/iconos/icon-512.png',
+  '/Carta-Nomo/icons/icon-192.png',
+  '/Carta-Nomo/icons/icon-512.png',
   '/Carta-Nomo/favicon.ico'
 ];
 


### PR DESCRIPTION
## Summary
- point apple-touch-icon link to /Carta-Nomo/icons/icon-192.png
- use /Carta-Nomo/icons/ assets in manifest and service worker
- confirm icons/ folder contains icon-192.png and icon-512.png

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906ca983f8832391398c1bf0abc11c