### PR TITLE
Handle precache installation failures gracefully

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -12,7 +12,19 @@ const APP_SHELL = [
 ];
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
+  event.waitUntil((async () => {
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const results = await Promise.allSettled(APP_SHELL.map((url) => cache.add(url)));
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          console.warn('Failed to precache', APP_SHELL[index], result.reason);
+        }
+      });
+    } catch (err) {
+      console.error('Failed to install service worker', err);
+    }
+  })());
   self.skipWaiting();
 });
 


### PR DESCRIPTION
## Summary
- wrap service worker install precache in async function
- log individual resource failures while precaching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890731434188323938b60c9538e7202