### PR TITLE
Add configurable BASE_PATH for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Una app web interactiva para visualizar, editar y escuchar palabras asociadas a 
   - Storage: subida de imágenes.
 - 📱 **PWA lista para móvil**: se puede instalar como app en dispositivos.
 
+## ⚙️ Configuración de rutas
+
+Las rutas a los recursos estáticos dependen del prefijo definido en `src/config.js`:
+
+```js
+export const BASE_PATH = '/Carta-Nomo';
+```
+
+- Para despliegues en GitHub Pages bajo `/Carta-Nomo` deja el valor por defecto.
+- Para servidores en la raíz del dominio usa cadena vacía `''` o `'/'`.
+
+Ajusta `BASE_PATH` según el entorno y los enlaces del manifiesto, iconos y Service Worker se actualizarán en consecuencia.
 
 ## 📄 Licencia
 

--- a/index.html
+++ b/index.html
@@ -5,15 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Carta Nomo · Sarria — Liquid Glass</title>
 
-  <!-- PWA en GitHub Pages (/Carta-Nomo/) -->
-  <link rel="manifest" href="/Carta-Nomo/manifest.json" />
   <meta name="theme-color" content="#ffffff" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-  <link rel="apple-touch-icon" href="/Carta-Nomo/icons/icon-192.png" />
-  <link rel="icon" href="/Carta-Nomo/favicon.ico" />
 
   <link rel="stylesheet" href="styles.css" />
+
+  <script type="module">
+    import { BASE_PATH } from "./src/config.js";
+    const addLink = (rel, href) => {
+      const link = document.createElement('link');
+      link.rel = rel;
+      link.href = href;
+      document.head.appendChild(link);
+    };
+    addLink('manifest', `${BASE_PATH}/manifest.json`);
+    addLink('apple-touch-icon', `${BASE_PATH}/icons/icon-192.png`);
+    addLink('icon', `${BASE_PATH}/favicon.ico`);
+  </script>
 </head>
 <body>
   <div class="page">
@@ -80,6 +89,7 @@
 
   <!-- Firebase SDKs (ESM desde CDN) -->
   <script type="module">
+    import { BASE_PATH } from "./src/config.js";
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
     import { getAuth, signInWithEmailAndPassword, signOut, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
     import { getFirestore, collection, doc, setDoc, deleteDoc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
@@ -256,7 +266,7 @@
 
     // Service Worker
     if ('serviceWorker' in navigator){
-      window.addEventListener('load', () => navigator.serviceWorker.register('/Carta-Nomo/service-worker.js'));
+      window.addEventListener('load', () => navigator.serviceWorker.register(`${BASE_PATH}/service-worker.js`, { type: 'module' }));
     }
   </script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,14 @@
   "short_name": "Carta Nomo",
   "description": "Explora la carta tocando números: muestra palabra e imagen, con lectura en voz alta.",
   "lang": "es-ES",
-  "start_url": "/Carta-Nomo/",
-  "scope": "/Carta-Nomo/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
-    { "src": "/Carta-Nomo/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/Carta-Nomo/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,14 +1,15 @@
-/* Service Worker para Carta Nomo (scope: /Carta-Nomo/) */
+/* Service Worker para Carta Nomo (scope: BASE_PATH) */
+import { BASE_PATH } from './src/config.js';
 const VERSION = 'v1.0.0';
 const CACHE_NAME = `carta-nomo-${VERSION}`;
 const APP_SHELL = [
-  '/Carta-Nomo/',
-  '/Carta-Nomo/index.html',
-  '/Carta-Nomo/styles.css',
-  '/Carta-Nomo/manifest.json',
-  '/Carta-Nomo/icons/icon-192.png',
-  '/Carta-Nomo/icons/icon-512.png',
-  '/Carta-Nomo/favicon.ico'
+  `${BASE_PATH}/`,
+  `${BASE_PATH}/index.html`,
+  `${BASE_PATH}/styles.css`,
+  `${BASE_PATH}/manifest.json`,
+  `${BASE_PATH}/icons/icon-192.png`,
+  `${BASE_PATH}/icons/icon-512.png`,
+  `${BASE_PATH}/favicon.ico`
 ];
 
 self.addEventListener('install', (event) => {
@@ -47,7 +48,7 @@ self.addEventListener('fetch', (event) => {
       fetch(request).then((res) => {
         const copy = res.clone(); if (copy.ok && copy.status === 200) caches.open(CACHE_NAME).then((c) => c.put(request, copy));
         return res;
-      }).catch(() => caches.match(request).then((r) => r || caches.match('/Carta-Nomo/index.html')))
+      }).catch(() => caches.match(request).then((r) => r || caches.match(`${BASE_PATH}/index.html`)))
     );
     return;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const BASE_PATH = '/Carta-Nomo';


### PR DESCRIPTION
## Summary
- centralize resource prefix in `BASE_PATH` configuration
- load manifest, icons and service worker paths using `BASE_PATH`
- document how to adjust `BASE_PATH` for different hosting paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689074ce912483238189b222d1ac5497