### PR TITLE
feat: generate service worker precache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ export const BASE_PATH = '/Carta-Nomo';
 
 Ajusta `BASE_PATH` según el entorno y los enlaces del manifiesto, iconos y Service Worker se actualizarán en consecuencia.
 
+## 🛠️ Generar el precache
+
+`service-worker.js` precarga archivos listados en `APP_SHELL`. Para mantener esta lista al día se incluye una tarea de build que la genera automáticamente a partir del contenido del directorio.
+
+```bash
+npm install        # solo la primera vez
+npm run build      # actualiza APP_SHELL
+```
+
+Ejecuta `npm run build` antes de desplegar para que el Service Worker contenga la lista más reciente de recursos estáticos.
+
 ## 📄 Licencia
 
 Este proyecto está bajo la licencia [MIT](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "carta-nomo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "carta-nomo",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "carta-nomo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build-sw": "node scripts/generate-app-shell.mjs",
+    "build": "npm run build-sw"
+  }
+}

--- a/scripts/generate-app-shell.mjs
+++ b/scripts/generate-app-shell.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const root = process.cwd();
+
+async function collectFiles() {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (entry.isFile()) {
+      if ([
+        'service-worker.js',
+        'package.json',
+        'package-lock.json',
+        'README.md',
+        'LICENSE',
+        '.gitignore'
+      ].includes(entry.name)) continue;
+      const ext = path.extname(entry.name);
+      if (['.html', '.css', '.js', '.json', '.ico', '.png', '.svg'].includes(ext)) {
+        files.push(entry.name);
+      }
+    } else if (entry.isDirectory() && entry.name === 'icons') {
+      const iconFiles = await fs.readdir(path.join(root, 'icons'));
+      for (const f of iconFiles) {
+        if (!f.startsWith('.')) {
+          files.push(`icons/${f}`);
+        }
+      }
+    }
+  }
+  files.sort();
+  return [''].concat(files);
+}
+
+function buildArray(files) {
+  const base = '${BASE_PATH}';
+  const lines = files.map((f) =>
+    f ? `  \`${base}/${f}\`` : `  \`${base}/\``
+  );
+  return `const APP_SHELL = [\n${lines.join(',\n')}\n];`;
+}
+
+async function updateServiceWorker() {
+  const files = await collectFiles();
+  const swPath = path.join(root, 'service-worker.js');
+  let sw = await fs.readFile(swPath, 'utf8');
+  sw = sw.replace(/const APP_SHELL = \[[\s\S]*?\];/, buildArray(files));
+  await fs.writeFile(swPath, sw);
+  console.log(`Updated APP_SHELL with ${files.length} entries.`);
+}
+
+updateServiceWorker().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,12 +4,11 @@ const VERSION = 'v1.0.0';
 const CACHE_NAME = `carta-nomo-${VERSION}`;
 const APP_SHELL = [
   `${BASE_PATH}/`,
-  `${BASE_PATH}/index.html`,
-  `${BASE_PATH}/styles.css`,
-  `${BASE_PATH}/manifest.json`,
   `${BASE_PATH}/icons/icon-192.png`,
   `${BASE_PATH}/icons/icon-512.png`,
-  `${BASE_PATH}/favicon.ico`
+  `${BASE_PATH}/index.html`,
+  `${BASE_PATH}/manifest.json`,
+  `${BASE_PATH}/styles.css`
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- script precaches static assets based on directory contents
- `service-worker.js` updated from build script
- document how to regenerate cache before deploy

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890768d76088323b5c9fe181b60c459