### PR TITLE
feat: add numeric limit constant

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,4 @@
 export const BASE_PATH = '/Carta-Nomo';
+
+// Número máximo de números gestionados por la aplicación
+export const MAX_NUMEROS = 100;

--- a/src/db.js
+++ b/src/db.js
@@ -1,5 +1,6 @@
 import { collection, doc, setDoc, deleteDoc, onSnapshot } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
 import { ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
+import { MAX_NUMEROS } from './config.js';
 
 export const subscribeNumeros = (db, callback) =>
   onSnapshot(collection(db, 'numeros'), (snap) => {
@@ -56,7 +57,7 @@ export async function importarArchivo(db, file) {
   const ops = [];
   for (const [k, v] of Object.entries(obj || {})) {
     const n = Number(k);
-    if (!Number.isInteger(n) || n < 1 || n > 100) continue;
+    if (!Number.isInteger(n) || n < 1 || n > MAX_NUMEROS) continue;
     ops.push(
       setDoc(doc(collection(db, 'numeros'), String(n)), {
         palabra: typeof v?.palabra === 'string' ? v.palabra : '',

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
 import { initAuth } from './auth.js';
 import { guardarNumero, borrarNumero, exportarDatos, importarArchivo, subscribeNumeros } from './db.js';
+import { MAX_NUMEROS } from './config.js';
 
 export function initUI({ auth, db, storage, BASE_PATH }) {
   const grid = document.getElementById('grid');
@@ -116,7 +117,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
   numSel.onchange = () => {
     let v = Math.max(
       1,
-      Math.min(100, parseInt(numSel.value || '1', 10))
+      Math.min(MAX_NUMEROS, parseInt(numSel.value || '1', 10))
     );
     numSel.value = v;
     seleccionado = v;
@@ -130,7 +131,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     try {
       const n = Math.max(
         1,
-        Math.min(100, parseInt(numSel.value || '1', 10))
+        Math.min(MAX_NUMEROS, parseInt(numSel.value || '1', 10))
       );
       const palabra = (palabraInput.value || '').trim();
       const file = imagenInput.files?.[0] || null;
@@ -185,7 +186,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     mostrar(seleccionado, false);
   });
 
-  for (let i = 1; i <= 100; i++) {
+  for (let i = 1; i <= MAX_NUMEROS; i++) {
     const cell = document.createElement('button');
     cell.className = 'cell';
     cell.type = 'button';
@@ -225,7 +226,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
       editBackdrop.getAttribute('aria-hidden') === 'false' ||
       loginBackdrop.getAttribute('aria-hidden') === 'false';
     if (anySheetOpen || isTextInput(document.activeElement)) return;
-    const max = 100;
+    const max = MAX_NUMEROS;
     let handled = false;
     if (e.key === 'ArrowRight') {
       seleccionado = Math.min(max, seleccionado + 1);


### PR DESCRIPTION
## Summary
- define and export `MAX_NUMEROS` in config
- reuse `MAX_NUMEROS` in db import validation
- apply `MAX_NUMEROS` across UI selection and navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68907b5bcda08323988995d84ed16d4f