### PR TITLE
Add popup view and keyboard navigation enhancements

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,6 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 const storage = getStorage(app);
 
-initUI({ auth, db, storage, BASE_PATH });
 // === Popup de vista ===
 const viewBackdrop = document.getElementById('viewBackdrop');
 const viewClose    = document.getElementById('viewClose');
@@ -39,6 +38,40 @@ const viewTitle    = document.getElementById('viewTitle');
 const viewDesc     = document.getElementById('viewDesc');
 
 function openView({ num, palabra, imageUrl }) {
-  viewTitle.textContent = `#${num} · ${palabra || 'Sin descripción'}`;
-  viewDesc.textContent
+  viewTitle.textContent = `#${num}`;
+  viewDesc.textContent = palabra || 'Sin descripción';
+  if (imageUrl) {
+    viewImg.src = imageUrl;
+    viewImg.style.display = '';
+  } else {
+    viewImg.removeAttribute('src');
+    viewImg.style.display = 'none';
+  }
+  viewBackdrop.style.display = 'flex';
+  viewBackdrop.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
 
+  const close = () => {
+    viewBackdrop.style.display = 'none';
+    viewBackdrop.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    viewClose.onclick = null;
+    viewBackdrop.removeEventListener('click', onBackdrop);
+    document.removeEventListener('keydown', onEsc);
+    const grid = document.getElementById('grid');
+    const cell = grid?.children?.[num - 1];
+    if (cell) cell.focus();
+  };
+
+  const onBackdrop = (e) => {
+    if (e.target === viewBackdrop) close();
+  };
+  const onEsc = (e) => {
+    if (e.key === 'Escape') close();
+  };
+  viewClose.onclick = close;
+  viewBackdrop.addEventListener('click', onBackdrop);
+  document.addEventListener('keydown', onEsc);
+}
+
+initUI({ auth, db, storage, BASE_PATH, openView });

--- a/src/ui.js
+++ b/src/ui.js
@@ -2,7 +2,7 @@ import { initAuth } from './auth.js';
 import { guardarNumero, borrarNumero, exportarDatos, importarArchivo, subscribeNumeros } from './db.js';
 import { MAX_NUMEROS } from './config.js';
 
-export function initUI({ auth, db, storage, BASE_PATH }) {
+export function initUI({ auth, db, storage, BASE_PATH, openView }) {
   const grid = document.getElementById('grid');
   const output = document.getElementById('output');
   const loginBtn = document.getElementById('loginBtn');
@@ -197,6 +197,11 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
       seleccionado = i;
       pintarSeleccion();
       mostrar(i);
+      openView({
+        num: i,
+        palabra: datos[i]?.palabra,
+        imageUrl: datos[i]?.imagenUrl,
+      });
     };
     cell.onkeydown = (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -204,6 +209,11 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
         seleccionado = i;
         pintarSeleccion();
         mostrar(i);
+        openView({
+          num: i,
+          palabra: datos[i]?.palabra,
+          imageUrl: datos[i]?.imagenUrl,
+        });
       }
     };
     grid.appendChild(cell);
@@ -238,6 +248,11 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     }
     if (e.key === 'Enter') {
       mostrar(seleccionado);
+      openView({
+        num: seleccionado,
+        palabra: datos[seleccionado]?.palabra,
+        imageUrl: datos[seleccionado]?.imagenUrl,
+      });
       handled = true;
     }
     if (!handled) return;


### PR DESCRIPTION
## Summary
- Implement `openView` to show number details in a popup with image, description and full close controls
- Trigger the new `openView` from grid cells and keyboard navigation

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68959fc67a8883239f57e7c0f64423c1