### PR TITLE
Show word in view title

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,8 +38,14 @@ const viewTitle    = document.getElementById('viewTitle');
 const viewDesc     = document.getElementById('viewDesc');
 
 function openView({ num, palabra, imageUrl }) {
-  viewTitle.textContent = `#${num}`;
-  viewDesc.textContent = palabra || 'Sin descripción';
+  viewTitle.textContent = palabra ? `${num}: ${palabra}` : `#${num}`;
+  if (palabra) {
+    viewDesc.style.display = 'none';
+    viewDesc.textContent = '';
+  } else {
+    viewDesc.style.display = '';
+    viewDesc.textContent = 'Sin descripción';
+  }
   if (imageUrl) {
     viewImg.src = imageUrl;
     viewImg.style.display = '';


### PR DESCRIPTION
## Summary
- display the selected word alongside its number in the viewer dialog title
- hide the description when the word is present, showing a default message only when no word exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a26f83f083238200fc3570c4456b