### PR TITLE
Add description field to numbers and viewer

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,21 +37,23 @@ const viewImg      = document.getElementById('viewImg');
 const viewTitle    = document.getElementById('viewTitle');
 const viewDesc     = document.getElementById('viewDesc');
 
-function openView({ num, palabra, imageUrl }) {
+function openView({ num, palabra, imageUrl, descripcion }) {
   viewTitle.textContent = palabra ? `${num}: ${palabra}` : `#${num}`;
-  if (palabra) {
-    viewDesc.style.display = 'none';
-    viewDesc.textContent = '';
-  } else {
-    viewDesc.style.display = '';
-    viewDesc.textContent = 'Sin descripción';
-  }
+
   if (imageUrl) {
     viewImg.src = imageUrl;
     viewImg.style.display = '';
   } else {
     viewImg.removeAttribute('src');
     viewImg.style.display = 'none';
+  }
+
+  if (descripcion) {
+    viewDesc.textContent = descripcion;
+    viewDesc.style.display = '';
+  } else {
+    viewDesc.textContent = '';
+    viewDesc.style.display = 'none';
   }
   viewBackdrop.style.display = 'flex';
   viewBackdrop.setAttribute('aria-hidden', 'false');

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
       <div class="body">
         <div class="row"><label for="numSel">Número</label><input type="number" id="numSel" min="1" max="100" inputmode="numeric" /></div>
         <div class="row"><label for="palabra">Palabra</label><input type="text" id="palabra" placeholder="Escribe la palabra…" /></div>
+        <div class="row"><label for="descripcion">Descripción</label><input type="text" id="descripcion" placeholder="Escribe la descripción…" /></div>
         <div class="row"><label for="imagen">Imagen (opcional)</label><input type="file" id="imagen" accept="image/*" /></div>
       </div>
       <div class="actions">

--- a/src/db.js
+++ b/src/db.js
@@ -11,12 +11,13 @@ export const subscribeNumeros = (db, callback) =>
         nuevo[n] = {
           palabra: d.data().palabra || '',
           imagenUrl: d.data().imagenUrl || null,
+          descripcion: d.data().descripcion || '',
         };
     });
     callback(nuevo);
   });
 
-export async function guardarNumero(db, storage, n, palabra, file) {
+export async function guardarNumero(db, storage, n, palabra, descripcion, file) {
   let imagenUrl = null;
   if (file) {
     const ref = storageRef(storage, `imagenes/${n}`);
@@ -28,6 +29,7 @@ export async function guardarNumero(db, storage, n, palabra, file) {
   }
   await setDoc(doc(collection(db, 'numeros'), String(n)), {
     palabra: palabra || '',
+    descripcion: descripcion || '',
     imagenUrl: imagenUrl || null,
     updatedAt: Date.now(),
   });
@@ -61,6 +63,7 @@ export async function importarArchivo(db, file) {
     ops.push(
       setDoc(doc(collection(db, 'numeros'), String(n)), {
         palabra: typeof v?.palabra === 'string' ? v.palabra : '',
+        descripcion: typeof v?.descripcion === 'string' ? v.descripcion : '',
         imagenUrl: typeof v?.imagenUrl === 'string' ? v.imagenUrl : null,
         updatedAt: Date.now(),
       })

--- a/src/ui.js
+++ b/src/ui.js
@@ -16,6 +16,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
   const editBackdrop = document.getElementById('editBackdrop');
   const numSel = document.getElementById('numSel');
   const palabraInput = document.getElementById('palabra');
+  const descripcionInput = document.getElementById('descripcion');
   const imagenInput = document.getElementById('imagen');
   const guardarBtn = document.getElementById('guardarBtn');
   const cancelarBtn = document.getElementById('cancelarBtn');
@@ -57,7 +58,10 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
 
   const tieneDatos = (n) => {
     const d = datos[n];
-    return !!(d && ((d.palabra && d.palabra.trim()) || d.imagenUrl));
+    return !!(
+      d &&
+      ((d.palabra && d.palabra.trim()) || d.imagenUrl || (d.descripcion && d.descripcion.trim()))
+    );
   };
   const refrescarCeldasVacias = () => {
     [...grid.children].forEach((el, ix) =>
@@ -96,6 +100,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
     const info = datos[seleccionado] || {};
     numSel.value = seleccionado;
     palabraInput.value = info.palabra || '';
+    descripcionInput.value = info.descripcion || '';
     imagenInput.value = '';
     editBackdrop.style.display = 'flex';
     editBackdrop.setAttribute('aria-hidden', 'false');
@@ -107,6 +112,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
     editBackdrop.setAttribute('aria-hidden', 'true');
     document.body.style.overflow = '';
     imagenInput.value = '';
+    descripcionInput.value = '';
   };
   editarBtn.onclick = openEdit;
   cancelarBtn.onclick = closeEdit;
@@ -124,6 +130,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
     pintarSeleccion();
     const info = datos[v] || {};
     palabraInput.value = info.palabra || '';
+    descripcionInput.value = info.descripcion || '';
     imagenInput.value = '';
   };
 
@@ -134,8 +141,9 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
         Math.min(MAX_NUMEROS, parseInt(numSel.value || '1', 10))
       );
       const palabra = (palabraInput.value || '').trim();
+      const descripcion = (descripcionInput.value || '').trim();
       const file = imagenInput.files?.[0] || null;
-      await guardarNumero(db, storage, n, palabra, file);
+      await guardarNumero(db, storage, n, palabra, descripcion, file);
       seleccionado = n;
       pintarSeleccion();
       closeEdit();
@@ -201,6 +209,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
         num: i,
         palabra: datos[i]?.palabra,
         imageUrl: datos[i]?.imagenUrl,
+        descripcion: datos[i]?.descripcion,
       });
     };
     cell.onkeydown = (e) => {
@@ -213,6 +222,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
           num: i,
           palabra: datos[i]?.palabra,
           imageUrl: datos[i]?.imagenUrl,
+          descripcion: datos[i]?.descripcion,
         });
       }
     };
@@ -252,6 +262,7 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
         num: seleccionado,
         palabra: datos[seleccionado]?.palabra,
         imageUrl: datos[seleccionado]?.imagenUrl,
+        descripcion: datos[seleccionado]?.descripcion,
       });
       handled = true;
     }


### PR DESCRIPTION
## Summary
- allow viewer to display optional description alongside number and image
- capture, save and load descriptions for each number in UI and database
- extend editing form with a description field

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a4a3e9b083239296888b36730c16