### PR TITLE
Preserve existing image and description when editing numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build-sw": "node scripts/generate-app-shell.mjs",
-    "build": "npm run build-sw"
+    "build": "npm run build-sw",
+    "test": "node --test"
   }
 }

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+
+async function loadGuardarNumero({ setDoc, getDoc }) {
+  const path = new URL('../src/db.js', import.meta.url);
+  let code = await readFile(path, 'utf8');
+  code = code.replace(/import[^\n]*firebase-firestore.js";\n/, '');
+  code = code.replace(/import[^\n]*firebase-storage.js";\n/, '');
+  code = code.replace(/import[^\n]*\.\/config.js';\n/, '');
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
+  globalThis.collection = () => ({});
+  globalThis.doc = () => ({});
+  globalThis.setDoc = setDoc;
+  globalThis.getDoc = getDoc;
+  globalThis.deleteDoc = () => {};
+  globalThis.onSnapshot = () => {};
+  globalThis.storageRef = () => ({});
+  globalThis.uploadBytes = async () => {};
+  globalThis.getDownloadURL = async () => {};
+  globalThis.deleteObject = async () => {};
+  const module = await import(dataUrl);
+  return module.guardarNumero;
+}
+
+test('editar sin nueva imagen mantiene imagenUrl y descripcion existentes', async () => {
+  const existente = { descripcion: 'vieja', imagenUrl: 'old.png' };
+
+  const getDocMock = async () => ({ exists: () => true, data: () => existente });
+  const calls = [];
+  const setDocMock = async (...args) => calls.push(args);
+
+  const guardarNumero = await loadGuardarNumero({ setDoc: setDocMock, getDoc: getDocMock });
+
+  await guardarNumero({}, {}, 5, 'cinco', undefined, null);
+
+  assert.strictEqual(calls.length, 1);
+  const dataArg = calls[0][1];
+  assert.strictEqual(dataArg.descripcion, 'vieja');
+  assert.strictEqual(dataArg.imagenUrl, 'old.png');
+  const opts = calls[0][2];
+  assert.deepStrictEqual(opts, { merge: true });
+});


### PR DESCRIPTION
## Summary
- preserve existing `imagenUrl` and `descripcion` when editing without new file or text
- merge updates into existing Firestore documents
- add unit test for editing numbers without new image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a7d3475c83238a74cb7344cd9e7a