### PR TITLE
Expose Firebase error details

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -26,23 +26,31 @@ export async function guardarNumero(db, storage, n, palabra, descripcion, file) 
   if (file) {
     const ref = storageRef(storage, `imagenes/${n}`);
     const bytes = new Uint8Array(await file.arrayBuffer());
-    await uploadBytes(ref, bytes, { contentType: file.type || 'image/png' });
-    imagenUrl = await getDownloadURL(ref);
+    try {
+      await uploadBytes(ref, bytes, { contentType: file.type || 'image/png' });
+      imagenUrl = await getDownloadURL(ref);
+    } catch (e) {
+      throw e;
+    }
   }
 
   let desc = actual.descripcion || '';
   if (descripcion !== undefined && descripcion !== null) desc = descripcion;
 
-  await setDoc(
-    dref,
-    {
-      palabra: palabra || '',
-      descripcion: desc,
-      imagenUrl,
-      updatedAt: Date.now(),
-    },
-    { merge: true }
-  );
+  try {
+    await setDoc(
+      dref,
+      {
+        palabra: palabra || '',
+        descripcion: desc,
+        imagenUrl,
+        updatedAt: Date.now(),
+      },
+      { merge: true }
+    );
+  } catch (e) {
+    throw e;
+  }
 }
 
 export async function borrarNumero(db, storage, n) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -148,7 +148,9 @@ export function initUI({ auth, db, storage, BASE_PATH, openView }) {
       pintarSeleccion();
       closeEdit();
     } catch (e) {
-      alert('Error al guardar: ' + (e?.message || e));
+      console.error('Error al guardar:', e?.code, e?.message);
+      const msg = [e?.code, e?.message].filter(Boolean).join(' - ');
+      alert('Error al guardar: ' + (msg || e));
     }
   };
 


### PR DESCRIPTION
## Summary
- show Firebase error `code` and `message` when saving from the UI
- wrap `uploadBytes` and `setDoc` in try/catch to surface errors to callers

## Testing
- `npm test`
- `node -e` snippet simulating `uploadBytes` failure
- `node -e` snippet simulating `setDoc` failure

------
https://chatgpt.com/codex/tasks/task_e_6895c6308b18832392d915e0895ef540