### PR TITLE
Reubicar bloque viewBackdrop dentro del body

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
   <link rel="stylesheet" href="styles.css" />
 
 </head>
-    <!-- Popup de vista (imagen + descripción) -->
+<body>
+  <!-- Popup de vista (imagen + descripción) -->
   <div id="viewBackdrop" class="backdrop" role="dialog" aria-modal="true" aria-hidden="true">
     <div class="glass sheet viewer" role="document">
       <button id="viewClose" class="btn icon" aria-label="Cerrar">✕</button>
@@ -32,7 +33,6 @@
     </div>
   </div>
 
-<body>
   <div class="page">
     <header class="glass appbar" role="banner">
       <div class="title">


### PR DESCRIPTION
## Summary
- Mover el bloque de vista `viewBackdrop` dentro del `<body>` antes del contenido principal.
- Asegurar que todo el contenido esté contenido en un único `<body>`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c8d788348323b0ddb78f37e4dd05