### PR TITLE
chore: align Firebase imports to v11

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // Importar Firebase
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-import { getStorage, ref, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js";
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
+import { getStorage, ref, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
 
 // Configuración Firebase
 const firebaseConfig = {


### PR DESCRIPTION
## Summary
- ensure all Firebase imports reference v11.0.1

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68962e2547ac8323be3157b4b7bc28a2