### PR TITLE
feat: surface delete errors

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,13 @@ const VERSION = 'v1.0.0';
 const CACHE_NAME = `carta-nomo-${VERSION}`;
 const APP_SHELL = [
   `${BASE_PATH}/`,
+  `${BASE_PATH}/app.js`,
+  `${BASE_PATH}/icons/android-chrome-192x192.png`,
+  `${BASE_PATH}/icons/android-chrome-512x512.png`,
+  `${BASE_PATH}/icons/apple-touch-icon.png`,
+  `${BASE_PATH}/icons/favicon-16x16.png`,
+  `${BASE_PATH}/icons/favicon-32x32.png`,
+  `${BASE_PATH}/icons/gitkeep.txt`,
   `${BASE_PATH}/icons/icon-192.png`,
   `${BASE_PATH}/icons/icon-512.png`,
   `${BASE_PATH}/index.html`,

--- a/src/db.js
+++ b/src/db.js
@@ -36,7 +36,10 @@ export async function guardarNumero(db, storage, n, palabra, file) {
 export async function borrarNumero(db, storage, n) {
   try {
     await deleteObject(storageRef(storage, `imagenes/${n}`));
-  } catch {}
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
   await deleteDoc(doc(collection(db, 'numeros'), String(n)));
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -152,6 +152,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     try {
       await borrarNumero(db, storage, n);
     } catch (e) {
+      console.error(e);
       alert('No se pudo borrar: ' + (e?.message || e));
     }
   };


### PR DESCRIPTION
## Summary
- log storage deletion failures and rethrow so callers can handle them
- surface delete errors to users and console in UI
- regenerate service worker app shell after build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689852382e1c8323980a82ccc80c3e9a