### PR TITLE
feat: externalize Firebase configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,40 @@ export const BASE_PATH = '/Carta-Nomo';
 
 Ajusta `BASE_PATH` según el entorno y los enlaces del manifiesto, iconos y Service Worker se actualizarán en consecuencia.
 
+## 🔑 Configuración de Firebase
+
+Las credenciales de Firebase no se incluyen en el repositorio. En producción debes proporcionarlas mediante variables de entorno o un archivo `firebaseConfig.json` ubicado junto a `index.html`.
+
+### Variables de entorno
+
+Antes de construir o ejecutar la app define estas variables:
+
+- `FIREBASE_API_KEY`
+- `FIREBASE_AUTH_DOMAIN`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_STORAGE_BUCKET`
+- `FIREBASE_MESSAGING_SENDER_ID`
+- `FIREBASE_APP_ID`
+- `FIREBASE_MEASUREMENT_ID`
+
+### Archivo `firebaseConfig.json`
+
+Si no usas variables de entorno, crea un archivo con la misma estructura que el objeto de configuración de Firebase y colócalo en la raíz pública del despliegue (mismo directorio que `index.html`). Ejemplo:
+
+```json
+{
+  "apiKey": "...",
+  "authDomain": "...",
+  "projectId": "...",
+  "storageBucket": "...",
+  "messagingSenderId": "...",
+  "appId": "...",
+  "measurementId": "..."
+}
+```
+
+No añadas este archivo al control de versiones.
+
 ## 🛠️ Generar el precache
 
 `service-worker.js` precarga archivos listados en `APP_SHELL`. Para mantener esta lista al día se incluye una tarea de build que la genera automáticamente a partir del contenido del directorio.

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import { getAuth } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth
 import { getFirestore } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
 import { getStorage } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
 import { initUI } from "./src/ui.js";
+import { loadFirebaseConfig } from "./src/firebaseConfig.js";
 
 const addLink = (rel, href) => {
   const link = document.createElement('link');
@@ -15,15 +16,7 @@ addLink('manifest', `${BASE_PATH}/manifest.json`);
 addLink('apple-touch-icon', `${BASE_PATH}/icons/icon-192.png`);
 addLink('icon', `${BASE_PATH}/favicon.ico`);
 
-const firebaseConfig = {
-  apiKey: "AIzaSyAqqDLPFmtAPHXm5ZzpHyxRZZpW31f4Of0",
-  authDomain: "carta-nomo.firebaseapp.com",
-  projectId: "carta-nomo",
-  storageBucket: "carta-nomo.firebasestorage.app",
-  messagingSenderId: "354109744323",
-  appId: "1:354109744323:web:d7548e8cfd0a1d4a41ae76",
-  measurementId: "G-LWB4H4F6TD"
-};
+const firebaseConfig = await loadFirebaseConfig();
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -1,0 +1,24 @@
+import { BASE_PATH } from './config.js';
+
+export async function loadFirebaseConfig() {
+  const env = globalThis?.process?.env ?? {};
+  const config = {
+    apiKey: env.FIREBASE_API_KEY,
+    authDomain: env.FIREBASE_AUTH_DOMAIN,
+    projectId: env.FIREBASE_PROJECT_ID,
+    storageBucket: env.FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: env.FIREBASE_MESSAGING_SENDER_ID,
+    appId: env.FIREBASE_APP_ID,
+    measurementId: env.FIREBASE_MEASUREMENT_ID,
+  };
+
+  if (Object.values(config).every(Boolean)) {
+    return config;
+  }
+
+  const response = await fetch(`${BASE_PATH}/firebaseConfig.json`, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error('Firebase configuration not found');
+  }
+  return await response.json();
+}


### PR DESCRIPTION
## Summary
- load Firebase credentials from environment variables or runtime JSON
- import external Firebase config in app startup
- document how to provide credentials during deployment

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898555045488323b4653fff866e8919