### PR TITLE
Handle errors when deleting numbers

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -40,7 +40,12 @@ export async function borrarNumero(db, storage, n) {
     console.error(e);
     throw e;
   }
-  await deleteDoc(doc(collection(db, 'numeros'), String(n)));
+  try {
+    await deleteDoc(doc(collection(db, 'numeros'), String(n)));
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
 }
 
 export function exportarDatos(datos) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -152,8 +152,9 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     try {
       await borrarNumero(db, storage, n);
     } catch (e) {
-      console.error(e);
+      console.error('Error al borrar número', e);
       alert('No se pudo borrar: ' + (e?.message || e));
+      return;
     }
   };
 


### PR DESCRIPTION
## Summary
- Log and rethrow errors when removing images and documents in `borrarNumero`.
- Surface deletion errors in the UI by alerting the user and logging them.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689855306f4c8323a359ab7d3c022c42