### PR TITLE
Rename imagenUrl to imageURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build-sw": "node scripts/generate-app-shell.mjs",
-    "build": "npm run build-sw"
+    "build": "npm run build-sw",
+    "migrate-image-field": "node scripts/migrate-imagen-url-field.mjs"
   }
 }

--- a/scripts/migrate-imagen-url-field.mjs
+++ b/scripts/migrate-imagen-url-field.mjs
@@ -1,0 +1,27 @@
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+initializeApp({ credential: applicationDefault() });
+
+const db = getFirestore();
+
+async function migrateImagenUrl() {
+  const snap = await db.collection('numeros').get();
+  const batch = db.batch();
+  snap.forEach((docSnap) => {
+    const data = docSnap.data();
+    if (data.imagenUrl && !data.imageURL) {
+      batch.update(docSnap.ref, {
+        imageURL: data.imagenUrl,
+        imagenUrl: FieldValue.delete(),
+      });
+    }
+  });
+  await batch.commit();
+  console.log('Migración completada');
+}
+
+migrateImagenUrl().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/ui.js
+++ b/src/ui.js
@@ -57,7 +57,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
 
   const tieneDatos = (n) => {
     const d = datos[n];
-    return !!(d && ((d.palabra && d.palabra.trim()) || d.imagenUrl));
+    return !!(d && ((d.palabra && d.palabra.trim()) || d.imageURL));
   };
   const refrescarCeldasVacias = () => {
     [...grid.children].forEach((el, ix) =>
@@ -75,11 +75,11 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
     const strong = document.createElement('strong');
     strong.textContent = `Número ${i}:`;
     output.append(strong, ' ', d?.palabra ?? '(sin datos)');
-    if (d?.imagenUrl) {
+    if (d?.imageURL) {
       const imgWrapper = document.createElement('div');
       const img = document.createElement('img');
       img.className = 'preview';
-      img.src = d.imagenUrl;
+      img.src = d.imageURL;
       img.loading = 'lazy';
       img.referrerPolicy = 'no-referrer';
       img.alt = d?.palabra


### PR DESCRIPTION
## Summary
- use `imageURL` instead of `imagenUrl` throughout data access and UI
- add Firestore migration helper and script to rename old `imagenUrl` documents
- expose migration script via npm script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68986215aa4c83239b5c5bea75c5972d