### PR TITLE
Preserve existing image when file absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build-sw": "node scripts/generate-app-shell.mjs",
     "build": "npm run build-sw",
-    "migrate-image-field": "node scripts/migrate-imagen-url-field.mjs"
+    "migrate-image-field": "node scripts/migrate-imagen-url-field.mjs",
+    "test": "node --test"
   }
 }

--- a/src/db.js
+++ b/src/db.js
@@ -7,6 +7,7 @@ import {
   getDocs,
   updateDoc,
   deleteField,
+  getDoc,
 } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
 import { ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-storage.js";
 import { MAX_NUMEROS } from './config.js';
@@ -33,7 +34,9 @@ export async function guardarNumero(db, storage, n, palabra, file) {
     await uploadBytes(ref, bytes, { contentType: file.type || 'image/png' });
     imageURL = await getDownloadURL(ref);
   } else {
-    imageURL = null;
+    const docRef = doc(collection(db, 'numeros'), String(n));
+    const snap = await getDoc(docRef);
+    imageURL = snap.exists() ? snap.data().imageURL || null : null;
   }
   await setDoc(doc(collection(db, 'numeros'), String(n)), {
     palabra: palabra || '',

--- a/test/guardarNumero.test.js
+++ b/test/guardarNumero.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(__dirname, '../src/db.js'), 'utf8');
+const startToken = 'export async function guardarNumero';
+const start = source.indexOf(startToken);
+const open = source.indexOf('{', start);
+let i = open + 1, depth = 1;
+while (depth > 0 && i < source.length) {
+  const ch = source[i];
+  if (ch === '{') depth++;
+  else if (ch === '}') depth--;
+  i++;
+}
+const fnCode = 'async function guardarNumero' + source.slice(startToken.length + start, i);
+
+const store = new Map();
+const context = {
+  Uint8Array,
+  collection: (db, name) => ({ db, name }),
+  doc: (colRef, id) => ({ colRef, id }),
+  setDoc: async (docRef, data) => { store.set(docRef.id, data); },
+  getDoc: async (docRef) => ({ exists: () => store.has(docRef.id), data: () => store.get(docRef.id) }),
+  storageRef: () => ({}),
+  uploadBytes: async () => {},
+  getDownloadURL: async () => 'nueva.png',
+};
+vm.createContext(context);
+vm.runInContext(fnCode, context);
+const { guardarNumero } = context;
+
+test('mantiene imagen existente si no se proporciona archivo', async () => {
+  const db = {};
+  const storage = {};
+  store.set('1', { palabra: 'vieja', imageURL: 'existente.png', updatedAt: 0 });
+
+  await guardarNumero(db, storage, 1, 'nueva', null);
+
+  const saved = store.get('1');
+  assert.equal(saved.imageURL, 'existente.png');
+  assert.equal(saved.palabra, 'nueva');
+});


### PR DESCRIPTION
## Summary
- retain previous imageURL when updating a number without a new file
- add test to ensure existing image persists
- expose npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898650cc7b8832399ebb57398ef3520