### PR TITLE
fix: correct manifest and favicon paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,9 +32,8 @@ const addLink = (rel, href) => {
   link.href = href;
   document.head.appendChild(link);
 };
-addLink('manifest', `${BASE_PATH}/manifest.json`);
-addLink('apple-touch-icon', `${BASE_PATH}/icons/icon-192.png`);
-addLink('icon', `${BASE_PATH}/favicon.ico`);
+addLink('apple-touch-icon', `${BASE_PATH}/icons/apple-touch-icon.png`);
+addLink('icon', `${BASE_PATH}/icons/favicon-32x32.png`);
 
 // Firebase
 const firebaseConfig = {

--- a/index.html
+++ b/index.html
@@ -4,10 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Carta Nomo · Sarria</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#ffffff" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />


### PR DESCRIPTION
## Summary
- point manifest tag to local manifest.json
- register apple touch and favicon icons via existing files
- remove duplicate link tags to avoid 404s in production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898664396c483238217070b4ace3064