### PR TITLE
Refactor popup styles into CSS classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,13 +85,13 @@
 
       <div class="body">
         <img id="viewImage" class="preview" alt="" />
-        <p id="viewDesc" class="subtitle" style="margin-top:10px"></p>
+        <p id="viewDesc" class="subtitle popup-desc"></p>
       </div>
 
-      <div class="actions" style="justify-content:space-between">
+      <div class="actions popup-actions">
         <button id="viewCloseBtn" class="btn">Cerrar</button>
         <!-- Zona admin: visible solo con sesión -->
-        <div id="viewAdminActions" class="admin-only" style="display:none; gap:10px">
+        <div id="viewAdminActions" class="admin-only popup-admin">
           <button id="viewEditBtn" class="btn primary">Editar</button>
           <button id="viewDeleteBtn" class="btn danger">Borrar</button>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -140,4 +140,7 @@ header.appbar{
 /* ——— Ajustes popup vista ——— */
 #viewImage{ max-width:min(320px, 70vw); width:100%; height:auto }
 .admin-only{ display:flex; align-items:center }
+.popup-desc{ margin-top:10px }
+.popup-actions{ justify-content:space-between }
+.popup-admin{ display:none; gap:10px }
 


### PR DESCRIPTION
## Summary
- remove inline styles from number detail popup
- define `.popup-desc`, `.popup-actions` and `.popup-admin` in `styles.css`
- apply new classes in `index.html`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68987307498483239907939d1fabb79a