### PR TITLE
Toggle modals with is-open class and aria attributes

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,12 +113,12 @@ async function upsertNumberDoc(n, { palabra, descripcion, imageURL }) {
 // Popup de vista
 // ————————————————————————————————————————————————
 function openView() {
-  viewBackdrop.style.display = 'flex';
-  viewBackdrop.setAttribute('aria-hidden', 'false');
+  viewBackdrop.classList.add('is-open');
+  viewBackdrop.removeAttribute('aria-hidden');
   viewCloseBtn?.focus();
 }
 function closeView() {
-  viewBackdrop.style.display = 'none';
+  viewBackdrop.classList.remove('is-open');
   viewBackdrop.setAttribute('aria-hidden', 'true');
   currentNumberSelected = null;
 }
@@ -166,8 +166,8 @@ viewEditBtn?.addEventListener('click', () => {
   // Extrae palabra del título "N. palabra"
   palabraInput.value = viewTitle.textContent.split('. ').slice(1).join('. ') || '';
   descInput.value = viewDesc.textContent || '';
-  editBackdrop.style.display = 'flex';
-  editBackdrop.setAttribute('aria-hidden', 'false');
+  editBackdrop.classList.add('is-open');
+  editBackdrop.removeAttribute('aria-hidden');
 });
 
 // Borrar desde popup
@@ -210,11 +210,11 @@ guardarBtn?.addEventListener('click', async () => {
     await upsertNumberDoc(n, { palabra, descripcion, imageURL });
 
     alert('Guardado con éxito');
-    editBackdrop.style.display = 'none';
+    editBackdrop.classList.remove('is-open');
     editBackdrop.setAttribute('aria-hidden', 'true');
 
     // Si el popup mostraba este número, refrescar su contenido
-    if (currentNumberSelected === Number(n) && viewBackdrop.style.display === 'flex') {
+    if (currentNumberSelected === Number(n) && viewBackdrop.classList.contains('is-open')) {
       renderView({ n: Number(n), palabra, descripcion, imageURL });
     }
   } catch (err) {

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ header.appbar{
 
 /* Modales */
 .backdrop{ position:fixed; inset:0; background:rgba(0,0,0,.45); display:none; align-items:flex-end; justify-content:center; padding: clamp(10px,3vw,16px); z-index:1000 }
+.backdrop.is-open{ display:flex }
 .sheet{ width:min(640px,96vw); border-radius: 24px; overflow:hidden; padding:0 }
 .sheet header{ padding:16px 16px 8px }
 .sheet h2{ margin:0; font-size: clamp(1.05rem,3vw,1.25rem) }


### PR DESCRIPTION
## Summary
- Add `.backdrop.is-open` CSS to display modal backdrop
- Switch modal logic in `app.js` to use `classList` and toggle `aria-hidden`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689873de3f84832387a2f6b373d18fd3