### PR TITLE
Ensure view popup exposes title and description to screen readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
   </div>
 
   <!-- Popup de vista (detalle número) -->
-  <div id="viewBackdrop" class="backdrop" role="dialog" aria-modal="true" aria-hidden="true">
+  <div id="viewBackdrop" class="backdrop" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="viewTitle" aria-describedby="viewDesc">
     <div class="glass sheet" role="document">
       <header>
         <h2 id="viewTitle">—</h2>

--- a/src/viewPopup.js
+++ b/src/viewPopup.js
@@ -7,12 +7,27 @@ let currentDescripcion = '';
 let currentImageURL = '';
 
 const viewBackdrop = document.getElementById('viewBackdrop');
-const viewTitle = document.getElementById('viewTitle');
+let viewTitle = document.getElementById('viewTitle');
 const viewImage = document.getElementById('viewImage');
-const viewDesc = document.getElementById('viewDesc');
+let viewDesc = document.getElementById('viewDesc');
 const viewCloseBtn = document.getElementById('viewCloseBtn');
 
+function ensureViewNodes() {
+  if (!viewTitle) {
+    viewTitle = document.createElement('h2');
+    viewTitle.id = 'viewTitle';
+    viewBackdrop.querySelector('header')?.appendChild(viewTitle);
+  }
+  if (!viewDesc) {
+    viewDesc = document.createElement('p');
+    viewDesc.id = 'viewDesc';
+    viewDesc.className = 'subtitle popup-desc';
+    viewBackdrop.querySelector('.body')?.appendChild(viewDesc);
+  }
+}
+
 function openView() {
+  ensureViewNodes();
   viewBackdrop.classList.add('is-open');
   viewBackdrop.removeAttribute('aria-hidden');
   viewCloseBtn?.focus();
@@ -25,6 +40,7 @@ function closeView() {
 }
 
 function renderView({ n, palabra, descripcion, imageURL }) {
+  ensureViewNodes();
   currentNumber = n;
   currentPalabra = palabra || '';
   currentDescripcion = descripcion || '';


### PR DESCRIPTION
## Summary
- Label view popup with title and description via `aria-labelledby` and `aria-describedby`
- Safeguard against missing popup title or description elements when activating the view

## Testing
- `npm test`
- `npx -y @axe-core/cli index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@axe-core%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68987776e3bc8323b9b5bf8a3fd7dc13