### PR TITLE
Use hidden class for admin elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,15 +86,15 @@ const exportCsvBtn = document.getElementById('exportCsvBtn');
 const importBtn = document.getElementById('importBtn');
 let isAdmin = false;
 
-onAuthStateChanged(auth, (user) => {
+  onAuthStateChanged(auth, (user) => {
   isAdmin = !!user;
   // Zona admin en el popup
-  if (viewAdminActions) viewAdminActions.style.display = isAdmin ? 'flex' : 'none';
+  if (viewAdminActions) viewAdminActions.classList.toggle('hidden', !isAdmin);
   // Botones admin
-  if (exportBtn) exportBtn.style.display = isAdmin ? '' : 'none';
-  if (exportCsvBtn) exportCsvBtn.style.display = isAdmin ? '' : 'none';
-  if (importBtn) importBtn.style.display = isAdmin ? '' : 'none';
-});
+  if (exportBtn) exportBtn.classList.toggle('hidden', !isAdmin);
+  if (exportCsvBtn) exportCsvBtn.classList.toggle('hidden', !isAdmin);
+  if (importBtn) importBtn.classList.toggle('hidden', !isAdmin);
+  });
 
 // ————————————————————————————————————————————————
 // Utilidades Firestore
@@ -314,7 +314,7 @@ exportCsvBtn?.addEventListener('click', async () => {
   const fileInput = document.createElement('input');
   fileInput.type = 'file';
   fileInput.accept = 'application/json';
-  fileInput.style.display = 'none';
+  fileInput.classList.add('hidden');
   document.body.appendChild(fileInput);
 
   importBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -26,13 +26,13 @@
       <div class="toolbar" role="toolbar" aria-label="Acciones">
         <span id="userInfo" class="subtitle" aria-live="polite">Sesión: invitado</span>
         <button id="loginBtn" class="btn">Iniciar sesión</button>
-        <button id="logoutBtn" class="btn" style="display:none">Salir</button>
-        <button id="editarBtn" class="btn primary" style="display:none">Editar</button>
-        <button id="borrarBtn" class="btn danger" style="display:none">Borrar</button>
+        <button id="logoutBtn" class="btn hidden">Salir</button>
+        <button id="editarBtn" class="btn primary hidden">Editar</button>
+        <button id="borrarBtn" class="btn danger hidden">Borrar</button>
         <!-- Botones admin -->
-        <button id="exportBtn" class="btn" style="display:none">Exportar JSON</button>
-        <button id="exportCsvBtn" class="btn" style="display:none">Exportar CSV</button>
-        <button id="importBtn" class="btn" style="display:none">Importar</button>
+        <button id="exportBtn" class="btn hidden">Exportar JSON</button>
+        <button id="exportCsvBtn" class="btn hidden">Exportar CSV</button>
+        <button id="importBtn" class="btn hidden">Importar</button>
       </div>
     </header>
 
@@ -91,7 +91,7 @@
       <div class="actions popup-actions">
         <button id="viewCloseBtn" class="btn">Cerrar</button>
         <!-- Zona admin: visible solo con sesión -->
-        <div id="viewAdminActions" class="admin-only popup-admin">
+        <div id="viewAdminActions" class="admin-only popup-admin hidden">
           <button id="viewEditBtn" class="btn primary">Editar</button>
           <button id="viewDeleteBtn" class="btn danger">Borrar</button>
         </div>

--- a/src/auth.js
+++ b/src/auth.js
@@ -18,12 +18,12 @@ export function initAuth(auth, elements) {
 
   const renderAuthUI = (user) => {
     const on = !!user;
-    editarBtn.style.display = on ? '' : 'none';
-    borrarBtn.style.display = on ? '' : 'none';
-    exportBtn.style.display = on ? '' : 'none';
-    importBtn.style.display = on ? '' : 'none';
-    logoutBtn.style.display = on ? '' : 'none';
-    loginBtn.style.display = on ? 'none' : '';
+    editarBtn.classList.toggle('hidden', !on);
+    borrarBtn.classList.toggle('hidden', !on);
+    exportBtn.classList.toggle('hidden', !on);
+    importBtn.classList.toggle('hidden', !on);
+    logoutBtn.classList.toggle('hidden', !on);
+    loginBtn.classList.toggle('hidden', on);
     userInfo.textContent = on ? `Sesión: ${user.email}` : 'Sesión: invitado';
   };
   onAuthStateChanged(auth, renderAuthUI);

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,7 @@ body{
     linear-gradient(160deg, var(--bg), var(--bg2));
 }
 
+.hidden{display:none}
 .page{max-width:var(--page-w); margin:0 auto; padding:clamp(14px,2.4vw,22px)}
 
 /* Vidrio líquido reutilizable */
@@ -143,7 +144,7 @@ header.appbar{
 .admin-only{ display:flex; align-items:center }
 .popup-desc{ margin-top:10px }
 .popup-actions{ justify-content:space-between }
-.popup-admin{ display:none; gap:10px }
+.popup-admin{ display:flex; gap:10px }
 
 
 /* Notificaciones */


### PR DESCRIPTION
## Summary
- add a reusable `.hidden` class in the stylesheet
- toggle admin buttons via `classList` instead of inline `style.display`
- default admin-only buttons and actions to the hidden state in the markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68987e7a92c48323b70e7dabe657ca16