### PR TITLE
Validate login fields before authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,16 @@
     <div class="glass sheet" role="document">
       <header><h2>Iniciar sesión</h2></header>
       <div class="body">
-        <div class="row"><label for="loginEmail">Correo</label><input type="email" id="loginEmail" /></div>
-        <div class="row"><label for="loginPass">Contraseña</label><input type="password" id="loginPass" /></div>
+        <div class="row">
+          <label for="loginEmail">Correo</label>
+          <input type="email" id="loginEmail" required aria-invalid="false" />
+          <div id="loginEmailError" class="error" aria-live="polite"></div>
+        </div>
+        <div class="row">
+          <label for="loginPass">Contraseña</label>
+          <input type="password" id="loginPass" required aria-invalid="false" />
+          <div id="loginPassError" class="error" aria-live="polite"></div>
+        </div>
       </div>
       <div class="actions">
         <button id="loginCancel" class="btn">Cancelar</button>


### PR DESCRIPTION
## Summary
- add required and aria-invalid attributes plus error message containers to login inputs
- validate email and password before calling Firebase auth and show field-specific errors
- disable "Entrar" button during authentication to prevent duplicate submissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a00a1c2c8323b24b34f132304733