### PR TITLE
feat: add description parameter to guardarNumero

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -20,13 +20,14 @@ export const subscribeNumeros = (db, callback) =>
       if (!isNaN(n))
         nuevo[n] = {
           palabra: d.data().palabra || '',
+          descripcion: d.data().descripcion || '',
           imageURL: d.data().imageURL || null,
         };
     });
     callback(nuevo);
   });
 
-export async function guardarNumero(db, storage, n, palabra, file) {
+export async function guardarNumero(db, storage, n, palabra, descripcion, file) {
   let imageURL = null;
   if (file) {
     const ref = storageRef(storage, `imagenes/${n}`);
@@ -40,6 +41,7 @@ export async function guardarNumero(db, storage, n, palabra, file) {
   }
   await setDoc(doc(collection(db, 'numeros'), String(n)), {
     palabra: palabra || '',
+    descripcion: descripcion || '',
     imageURL: imageURL || null,
     updatedAt: Date.now(),
   });
@@ -73,6 +75,7 @@ export async function importarArchivo(db, file) {
     ops.push(
       setDoc(doc(collection(db, 'numeros'), String(n)), {
         palabra: typeof v?.palabra === 'string' ? v.palabra : '',
+        descripcion: typeof v?.descripcion === 'string' ? v.descripcion : '',
         imageURL: typeof v?.imageURL === 'string' ? v.imageURL : null,
         updatedAt: Date.now(),
       })

--- a/src/ui.js
+++ b/src/ui.js
@@ -136,7 +136,7 @@ export function initUI({ auth, db, storage, BASE_PATH }) {
   //     );
   //     const palabra = (palabraInput.value || '').trim();
   //     const file = imagenInput.files?.[0] || null;
-  //     await guardarNumero(db, storage, n, palabra, file);
+  //     await guardarNumero(db, storage, n, palabra, descripcion, file);
   //     seleccionado = n;
   //     pintarSeleccion();
   //     closeEdit();

--- a/test/guardarNumero.test.js
+++ b/test/guardarNumero.test.js
@@ -37,11 +37,12 @@ const { guardarNumero } = context;
 test('mantiene imagen existente si no se proporciona archivo', async () => {
   const db = {};
   const storage = {};
-  store.set('1', { palabra: 'vieja', imageURL: 'existente.png', updatedAt: 0 });
+  store.set('1', { palabra: 'vieja', descripcion: 'desc vieja', imageURL: 'existente.png', updatedAt: 0 });
 
-  await guardarNumero(db, storage, 1, 'nueva', null);
+  await guardarNumero(db, storage, 1, 'nueva', 'desc nueva', null);
 
   const saved = store.get('1');
   assert.equal(saved.imageURL, 'existente.png');
   assert.equal(saved.palabra, 'nueva');
+  assert.equal(saved.descripcion, 'desc nueva');
 });


### PR DESCRIPTION
## Summary
- allow guardarNumero to store a descripcion alongside palabra and image URL
- track descripcion in realtime subscription and imports
- extend tests for guardarNumero to include descripcion handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a98db1488323b4aad9e514d083da