### PR TITLE
Add speech synthesis for selected numbers

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,6 +74,17 @@ export async function fetchNumberDoc(n) {
   return { id: ref.id, ...snap.data() };
 }
 
+export function speak(text) {
+  const synth = window.speechSynthesis;
+  if (!synth) return;
+  synth.cancel();
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = 'es-ES';
+  utterance.rate = 1;
+  utterance.pitch = 1;
+  synth.speak(utterance);
+}
+
 // Click en celdas -> abrir popup
 grid?.addEventListener('click', async (e) => {
   const cell = e.target.closest('.cell');
@@ -89,4 +100,5 @@ grid?.addEventListener('click', async (e) => {
     imageURL: docData?.imageURL || ''
   });
   openView();
+  if (docData?.palabra) speak(docData.palabra);
 });


### PR DESCRIPTION
## Summary
- add `speak` helper using Web Speech API to pronounce words in Spanish
- play number's word when selecting a grid cell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae6d4bec8323ad084cec2445ae83