### PR TITLE
feat: add CSV import support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -30,6 +30,7 @@
         <button id="exportBtn" class="btn">Exportar JSON</button>
         <button id="exportCsvBtn" class="btn">Exportar CSV</button>
         <button id="importBtn" class="btn">Importar</button>
+        <button id="importCsvBtn" class="btn">Importar CSV</button>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- add CSV import button to admin toolbar
- implement CSV import with progress feedback and Firestore updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b09865c8832383e20e386f17d57f