### PR TITLE
Add speech synthesis button for item descriptions

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -77,6 +77,7 @@
       </div>
 
       <div class="actions popup-actions">
+        <button id="viewSpeakBtn" class="btn">Escuchar descripción</button>
         <button id="viewCloseBtn" class="btn">Cerrar</button>
         <div id="viewAdminActions" class="admin-only popup-admin">
           <button id="viewEditBtn" class="btn primary">Editar</button>

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       </div>
 
       <div class="actions popup-actions">
+        <button id="viewSpeakBtn" class="btn">Escuchar descripción</button>
         <button id="viewCloseBtn" class="btn">Cerrar</button>
       </div>
     </div>

--- a/src/viewPopup.js
+++ b/src/viewPopup.js
@@ -11,6 +11,7 @@ let viewTitle = document.getElementById('viewTitle');
 const viewImage = document.getElementById('viewImage');
 let viewDesc = document.getElementById('viewDesc');
 const viewCloseBtn = document.getElementById('viewCloseBtn');
+const viewSpeakBtn = document.getElementById('viewSpeakBtn');
 
 function ensureViewNodes() {
   if (!viewTitle) {
@@ -77,11 +78,26 @@ function getCurrentData() {
   };
 }
 
+function speakDesc() {
+  if (!currentDescripcion) return;
+  try {
+    const synth = window.speechSynthesis;
+    if (!synth) return;
+    synth.cancel();
+    const u = new SpeechSynthesisUtterance(currentDescripcion);
+    u.lang = 'es-ES';
+    u.rate = 1;
+    u.pitch = 1;
+    synth.speak(u);
+  } catch {}
+}
+
 // Eventos internos de cierre
 viewBackdrop?.addEventListener('click', (e) => {
   if (e.target === viewBackdrop) closeView();
 });
 viewCloseBtn?.addEventListener('click', closeView);
+viewSpeakBtn?.addEventListener('click', speakDesc);
 window.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') closeView();
 });


### PR DESCRIPTION
## Summary
- Add "Escuchar descripción" button to detail popup in public and admin views
- Implement speechSynthesis playback of item description in viewPopup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b552351c8323a8762d1945ba3a6e